### PR TITLE
Fix not sending report if project reuses configuration cache and `attachGradleScanId` is `true`

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -21,7 +21,16 @@ dependencies {
     implementation("io.ktor:ktor-client-serialization:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0")
 
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(gradleTestKit())
+    testImplementation("org.assertj:assertj-core:3.24.2")
+
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.3")
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
 }
 
 java {

--- a/plugin/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/plugin/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -1,0 +1,79 @@
+package com.automattic.android.measure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@Suppress("MaximumLineLength", "MaxLineLength")
+class BuildTimePluginTest {
+
+    @Test
+    fun `given a project that attaches gradle scan id, when executing a task with configuration from cache, then send the report with attached gradle scan id`() {
+        // given
+        val runner = functionalTestRunner()
+
+        // when
+        val prepareConfigurationCache = runner.withArguments("--configuration-cache", "help").build()
+
+        // then
+        assertThat(prepareConfigurationCache.output)
+            .contains("Calculating task graph as no configuration cache is available for tasks")
+            .contains("Configuration cache entry stored")
+
+        // when
+        val buildUsingConfigurationCache = runner.withArguments("--configuration-cache", "help", "--debug").build()
+
+        // then
+        assertThat(buildUsingConfigurationCache.output)
+            .contains("Reusing configuration cache")
+            .contains("Reporting build data to Apps Metrics...")
+            .contains("{\"name\":\"woocommerce-gradle-scan-id\",\"value\":")
+            .doesNotContain("{\"name\":\"woocommerce-gradle-scan-id\",\"value\":\"null\"}")
+    }
+
+    @BeforeEach
+    fun clearCache() {
+        val projectDir = File("build/tmp/test/work/.gradle-test-kit/caches")
+        projectDir.deleteRecursively()
+    }
+
+    private fun functionalTestRunner(vararg arguments: String): GradleRunner {
+        val projectDir = File("build/functionalTest")
+        projectDir.mkdirs()
+        projectDir.resolve("settings.gradle.kts").writeText(
+            """
+            plugins {
+                id("com.gradle.enterprise") version "3.15.1"
+            }
+            gradleEnterprise {
+                buildScan {
+                    publishAlways()
+                    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                    termsOfServiceAgree = "yes"
+                }
+            }
+            """.trimIndent()
+        )
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("com.automattic.android.measure-builds")
+            }
+            measureBuilds {
+                attachGradleScanId.set(true)
+                automatticProject.set(com.automattic.android.measure.MeasureBuildsExtension.AutomatticProject.WooCommerce)
+            }
+        """
+        )
+        projectDir.resolve("gradle.properties").writeText("appsMetricsToken=token")
+
+        val runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments(arguments.toList())
+        runner.withProjectDir(projectDir)
+        return runner
+    }
+}


### PR DESCRIPTION
Closes: #17 

### Description

If build uses configuration cache and configuration inputs are not changed, the `project#afterEvaluate` won't be executed and `buildScanPublished` listener won't be attached.

So moving setting up `buildScanPublished` outside `projectEvaluate` addresses the problem. I had to remove `NO_GRADLE_ENTERPRISE_PLUGIN_MESSAGE` warning though, as outside `afterEvaluate`, the extension is not yet ready to query.