### PR TITLE
fix: do not crash build if `appsMetricsToken` was not provided

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -30,6 +30,8 @@ class BuildTimePlugin @Inject constructor(
     override fun apply(project: Project) {
         val startTime =
             (project.gradle as DefaultGradle).services[BuildStartedTime::class.java].startTime
+        val extension =
+            project.extensions.create("measureBuilds", MeasureBuildsExtension::class.java, project)
 
         val authToken = AuthTokenProvider.provide(project)
         if (authToken.isNullOrBlank()) {
@@ -38,9 +40,6 @@ class BuildTimePlugin @Inject constructor(
         }
 
         val analyticsReporter = MetricsReporter(project.logger, authToken)
-
-        val extension =
-            project.extensions.create("measureBuilds", MeasureBuildsExtension::class.java, project)
 
         val encodedUser: String = UsernameProvider.provide(project, extension)
 

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -98,6 +98,24 @@ class BuildTimePluginTest {
         assertThat(run.output).doesNotContain("Reporting build data to Apps Metrics...")
     }
 
+    @Test
+    fun `given a project without apps metrics token, when executing a task, then build does not fail`() {
+        // given
+        val runner = functionalTestRunner(
+            enable = true,
+            attachGradleScanId = false,
+            applyAppsMetricsToken = false,
+        )
+
+        // when
+        val run = runner.withArguments("help").build()
+
+        // then
+        assertThat(run.output)
+            .contains("Did not find appsMetricsToken in gradle.properties. Skipping reporting.")
+            .contains("BUILD SUCCESSFUL")
+    }
+
     @BeforeEach
     fun clearCache() {
         val projectDir = File("build/functionalTest")
@@ -107,7 +125,8 @@ class BuildTimePluginTest {
     private fun functionalTestRunner(
         enable: Boolean?,
         attachGradleScanId: Boolean,
-        vararg arguments: String
+        applyAppsMetricsToken: Boolean = true,
+        vararg arguments: String,
     ): GradleRunner {
         val projectDir = File("build/functionalTest")
         projectDir.mkdirs()
@@ -138,7 +157,9 @@ class BuildTimePluginTest {
             }
             """.trimIndent()
         )
-        projectDir.resolve("gradle.properties").writeText("appsMetricsToken=token")
+        if (applyAppsMetricsToken) {
+            projectDir.resolve("gradle.properties").writeText("appsMetricsToken=token")
+        }
 
         val runner = GradleRunner.create()
         runner.forwardOutput()


### PR DESCRIPTION
### Description

This PR fixes a build failure when user did not provide `appsMetricsToken`. The reason for this bug was in order of validating if a project has a token vs. registering extension of the plugin.

We have to register the extension, even if the plugin will not be used, to assert that Gradle knows what the `measureBuilds` closure is.