### PR TITLE
feat: measure configuration phase duration

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -15,6 +15,8 @@ import org.gradle.api.flow.FlowProviders
 import org.gradle.api.flow.FlowScope
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.internal.buildevents.BuildStartedTime
+import org.gradle.invocation.DefaultGradle
 import javax.inject.Inject
 import kotlin.time.ExperimentalTime
 
@@ -26,7 +28,8 @@ class BuildTimePlugin @Inject constructor(
     private val flowProviders: FlowProviders,
 ) : Plugin<Project> {
     override fun apply(project: Project) {
-        val buildInitiatedTime = System.currentTimeMillis()
+        val buildInitiatedTime =
+            (project.gradle as DefaultGradle).services[BuildStartedTime::class.java].startTime
         val extension =
             project.extensions.create("measureBuilds", MeasureBuildsExtension::class.java, project)
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -27,7 +27,7 @@ class BuildTimePlugin @Inject constructor(
     private val flowProviders: FlowProviders,
 ) : Plugin<Project> {
     override fun apply(project: Project) {
-        val startTime =
+        val buildStartTime =
             (project.gradle as DefaultGradle).services[BuildStartedTime::class.java].startTime
         val extension =
             project.extensions.create("measureBuilds", MeasureBuildsExtension::class.java, project)
@@ -38,9 +38,9 @@ class BuildTimePlugin @Inject constructor(
 
         project.afterEvaluate {
             if (extension.enable.orNull == true) {
-                prepareBuildData(project, extension, encodedUser)
+                prepareBuildData(project, extension, encodedUser, buildStartTime)
                 prepareBuildTaskService(project)
-                prepareBuildFinishedAction(extension, analyticsReporter, startTime)
+                prepareBuildFinishedAction(extension, analyticsReporter, buildStartTime)
             }
         }
 
@@ -50,13 +50,15 @@ class BuildTimePlugin @Inject constructor(
     private fun prepareBuildData(
         project: Project,
         extension: MeasureBuildsExtension,
-        encodedUser: String
+        encodedUser: String,
+        buildStartTime: Long,
     ) {
         InMemoryReport.buildDataStore =
             BuildDataProvider.provide(
                 project,
                 extension.automatticProject.get(),
-                encodedUser
+                encodedUser,
+                buildStartTime
             )
     }
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -28,8 +28,7 @@ class BuildTimePlugin @Inject constructor(
     private val flowProviders: FlowProviders,
 ) : Plugin<Project> {
     override fun apply(project: Project) {
-        val buildInitiatedTime =
-            (project.gradle as DefaultGradle).services[BuildStartedTime::class.java].startTime
+        val buildInitiatedTime = System.currentTimeMillis()
         val extension =
             project.extensions.create("measureBuilds", MeasureBuildsExtension::class.java, project)
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -15,8 +15,6 @@ import org.gradle.api.flow.FlowProviders
 import org.gradle.api.flow.FlowScope
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
-import org.gradle.internal.buildevents.BuildStartedTime
-import org.gradle.invocation.DefaultGradle
 import javax.inject.Inject
 import kotlin.time.ExperimentalTime
 
@@ -38,7 +36,9 @@ class BuildTimePlugin @Inject constructor(
 
         project.afterEvaluate {
             if (extension.enable.orNull == true) {
-                val configurationProvider: Provider<Boolean> = project.providers.of(ConfigurationPhaseObserver::class.java) { }
+                val configurationProvider: Provider<Boolean> = project.providers.of(
+                    ConfigurationPhaseObserver::class.java
+                ) { }
                 ConfigurationPhaseObserver.init()
 
                 prepareBuildData(project, extension, encodedUser)

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
@@ -44,7 +44,7 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
         val buildTime = finish - init
 
         val configurationTime = if (parameters.configurationPhaseExecuted.get().get()) {
-            init - parameters.buildTaskService.get().buildStartTime
+            parameters.buildTaskService.get().buildStartTime - init
         } else {
             0
         }

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildTaskService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildTaskService.kt
@@ -22,6 +22,8 @@ abstract class BuildTaskService :
     val tasks: List<MeasuredTask>
         get() = measuredTasks
 
+    val buildStartTime: Long = System.currentTimeMillis()
+
     override fun onFinish(event: FinishEvent?) {
         if (event is TaskFinishEvent) {
             if (event.result is SuccessResult) {

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/ConfigurationPhaseObserver.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/ConfigurationPhaseObserver.kt
@@ -1,0 +1,19 @@
+package com.automattic.android.measure.lifecycle
+
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+abstract class ConfigurationPhaseObserver : ValueSource<Boolean, ValueSourceParameters.None> {
+    override fun obtain(): Boolean {
+        return configurationExecuted.also {
+            configurationExecuted = false
+        }
+    }
+
+    companion object {
+        private var configurationExecuted = false
+        fun init() {
+            configurationExecuted = true
+        }
+    }
+}

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -18,6 +18,7 @@ data class BuildData(
     val buildDataCollectionOverhead: Long,
     val includedBuildsNames: List<String>,
     val architecture: String,
+    val configurationPhaseDuration: Long,
 )
 
 data class ExecutionData(

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -18,7 +18,6 @@ data class BuildData(
     val buildDataCollectionOverhead: Long,
     val includedBuildsNames: List<String>,
     val architecture: String,
-    val configurationPhaseDuration: Long,
 )
 
 data class ExecutionData(
@@ -27,6 +26,7 @@ data class ExecutionData(
     val failure: Throwable?,
     val tasks: List<MeasuredTask>,
     val buildFinishedTimestamp: Long,
+    val configurationPhaseDuration: Long,
 )
 
 enum class Environment {

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -38,7 +38,7 @@ fun Report.toAppsInfraPayload(gradleScanId: String?): GroupedAppsMetrics {
             .ifEmpty { "none" },
         "build-finished-at" to executionData.buildFinishedTimestamp.toString(),
         "gradle-scan-id" to gradleScanId.orEmpty(),
-        "configuration-duration" to buildData.configurationPhaseDuration.toString()
+        "configuration-duration" to executionData.configurationPhaseDuration.toString()
     )
 
     val tasks = executionData.tasks.map {

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -38,6 +38,7 @@ fun Report.toAppsInfraPayload(gradleScanId: String?): GroupedAppsMetrics {
             .ifEmpty { "none" },
         "build-finished-at" to executionData.buildFinishedTimestamp.toString(),
         "gradle-scan-id" to gradleScanId.orEmpty(),
+        "configuration-duration" to buildData.configurationPhaseDuration.toString()
     )
 
     val tasks = executionData.tasks.map {

--- a/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
@@ -17,7 +17,7 @@ object BuildDataProvider {
         username: String,
         buildStartTime: Long,
     ): BuildData {
-        val configurationPhaseFinishedTime = nowMillis()
+        val configurationPhaseFinishedTime = System.currentTimeMillis()
         val gradle = project.gradle
 
         val services = (gradle as DefaultGradle).services

--- a/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
@@ -15,8 +15,9 @@ object BuildDataProvider {
         project: Project,
         automatticProject: MeasureBuildsExtension.AutomatticProject,
         username: String,
+        buildStartTime: Long,
     ): BuildData {
-        val start = nowMillis()
+        val configurationPhaseFinishedTime = nowMillis()
         val gradle = project.gradle
 
         val services = (gradle as DefaultGradle).services
@@ -37,10 +38,11 @@ object BuildDataProvider {
             isConfigurationCache = startParameter.isConfigurationCacheRequested,
             isBuildCache = startParameter.isBuildCacheEnabled,
             maxWorkers = startParameter.maxWorkerCount,
-            buildDataCollectionOverhead = nowMillis() - start,
+            buildDataCollectionOverhead = nowMillis() - configurationPhaseFinishedTime,
             includedBuildsNames = gradle.includedBuilds.toList().map { it.name },
             architecture = architecture(project),
-            user = username
+            user = username,
+            configurationPhaseDuration = configurationPhaseFinishedTime - buildStartTime
         )
     }
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/providers/BuildDataProvider.kt
@@ -15,7 +15,6 @@ object BuildDataProvider {
         project: Project,
         automatticProject: MeasureBuildsExtension.AutomatticProject,
         username: String,
-        buildStartTime: Long,
     ): BuildData {
         val configurationPhaseFinishedTime = System.currentTimeMillis()
         val gradle = project.gradle
@@ -42,7 +41,6 @@ object BuildDataProvider {
             includedBuildsNames = gradle.includedBuilds.toList().map { it.name },
             architecture = architecture(project),
             user = username,
-            configurationPhaseDuration = configurationPhaseFinishedTime - buildStartTime
         )
     }
 


### PR DESCRIPTION
### Description

This PR adds a new metric, `configuration-duration`, to measure time spent on initialization and configuration of Android builds.

#### How does it work?

If `project#afetEvaluate` is executed, it means that the configuration phase was executed. Then, `ConfigurationPhaseObserver#init` is called and  `ConfigurationPhaseObserver#obtain` returns `true`, and resets its internal state to `false` immediately after.

If `project#afetEvaluate` is not executed, it means that the build used the Configuration Cache feature. Because we reset the internal state of `ConfigurationPhaseObserver` to `false`, it will return `false` in case of being retrieved from Configuration Cache, giving the expected result.

The value of Configuration Phase duration is calculated via subtracting the build initiation time, provided by `BuildStartedTime`, and build start time, assigned in constructor of `BuildTaskService`.