### PR TITLE
fix: build time duration is calculated from cached values

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -45,11 +45,11 @@ class BuildTimePlugin @Inject constructor(
                 ConfigurationPhaseObserver.init()
 
                 prepareBuildData(project, extension, encodedUser)
-                prepareBuildTaskService(project)
                 prepareBuildFinishedAction(extension, analyticsReporter, buildInitiatedTime, configurationProvider)
             }
         }
 
+        prepareBuildTaskService(project)
         prepareBuildScanListener(project, extension, analyticsReporter)
     }
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
@@ -17,6 +17,9 @@ import kotlin.jvm.optionals.getOrNull
 
 class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
     interface Parameters : FlowParameters {
+
+        // This value will NOT update if project re-used configuration cache
+        // Use ONLY for calculating configuration phase duration is it was executed
         @get:Input
         val initiationTime: Property<Long>
 
@@ -38,19 +41,20 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
 
     override fun execute(parameters: Parameters) {
         val init = parameters.initiationTime.get()
+        val buildStart = parameters.buildTaskService.get().buildStartTime
         val finish = System.currentTimeMillis()
 
         val result = parameters.buildWorkResult.get().get()
-        val buildTime = finish - init
+        val buildPhaseDuration = finish - buildStart
 
         val configurationTime = if (parameters.configurationPhaseExecuted.get().get()) {
-            parameters.buildTaskService.get().buildStartTime - init
+            buildStart - init
         } else {
             0
         }
 
         val executionData = ExecutionData(
-            buildTime = buildTime,
+            buildTime = buildPhaseDuration + configurationTime,
             failed = result.failure.isPresent,
             failure = result.failure.getOrNull()?.message,
             tasks = parameters.buildTaskService.get().tasks,

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
@@ -19,7 +19,7 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
     interface Parameters : FlowParameters {
 
         // This value will NOT update if project re-used configuration cache
-        // Use ONLY for calculating configuration phase duration is it was executed
+        // Use ONLY for calculating configuration phase duration if it was executed
         @get:Input
         val initiationTime: Property<Long>
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
@@ -149,6 +149,10 @@ class MetricsReporter(
     }
 
     private fun logSlowTasks(report: InMemoryReport) {
+        if (report.executionData.buildTime == 0L) {
+            return
+        }
+
         val slowTasks =
             report.executionData.tasks.sortedByDescending { it.duration }.chunked(atMostLoggedTasks)
                 .first()


### PR DESCRIPTION
Fix how build time duration is calculated.

As `buildInitiatedTime` from `BuildTimePlugin#apply` will be cached, it would provide incorrect values.