### PR TITLE
Save build and execution reports locally

### DIFF
--- a/measure-builds/build.gradle.kts
+++ b/measure-builds/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:1.6.4")
     implementation("io.ktor:ktor-client-logging:1.6.4")
     implementation("io.ktor:ktor-client-serialization:1.6.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -58,12 +58,13 @@ class BuildTimePlugin @Inject constructor(
         extension: MeasureBuildsExtension,
         encodedUser: String,
     ) {
-        InMemoryReport.buildDataStore =
+        InMemoryReport.setBuildData(
             BuildDataProvider.provide(
                 project,
                 extension.automatticProject.get(),
                 encodedUser,
             )
+        )
     }
 
     private fun prepareBuildScanListener(

--- a/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
@@ -3,18 +3,21 @@ package com.automattic.android.measure
 import com.automattic.android.measure.models.BuildData
 import com.automattic.android.measure.models.ExecutionData
 
-object InMemoryReport : Report {
-    var buildDataStore: BuildData? = null
-    var executionDataStore: ExecutionData? = null
+object InMemoryReport {
+    private var buildDataStore: BuildData? = null
+    private var executionDataStore: ExecutionData? = null
 
-    override val buildData: BuildData
+    fun setBuildData(buildData: BuildData) {
+        buildDataStore = buildData
+    }
+
+    fun setExecutionData(executionData: ExecutionData) {
+        executionDataStore = executionData
+    }
+
+    val buildData: BuildData
         get() = buildDataStore ?: throw NullPointerException("Must not be null")
 
-    override val executionData: ExecutionData
-        get() = executionDataStore ?: throw NullPointerException("Must not be null")
-}
-
-interface Report {
-    val buildData: BuildData
     val executionData: ExecutionData
+        get() = executionDataStore ?: throw NullPointerException("Must not be null")
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
@@ -52,13 +52,13 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
         val executionData = ExecutionData(
             buildTime = buildTime,
             failed = result.failure.isPresent,
-            failure = result.failure.getOrNull(),
+            failure = result.failure.getOrNull()?.message,
             tasks = parameters.buildTaskService.get().tasks,
             buildFinishedTimestamp = finish,
             configurationPhaseDuration = configurationTime
         )
 
-        InMemoryReport.executionDataStore = executionData
+        InMemoryReport.setExecutionData(executionData)
 
         if (parameters.attachGradleScanId.get() == false) {
             runBlocking {

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -1,7 +1,9 @@
 package com.automattic.android.measure.models
 
 import com.automattic.android.measure.MeasureBuildsExtension
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class BuildData(
     val forProject: MeasureBuildsExtension.AutomatticProject,
     val user: String,
@@ -19,10 +21,11 @@ data class BuildData(
     val architecture: String,
 )
 
+@Serializable
 data class ExecutionData(
     val buildTime: Long,
     val failed: Boolean,
-    val failure: Throwable?,
+    val failure: String?,
     val tasks: List<MeasuredTask>,
     val buildFinishedTimestamp: Long,
     val configurationPhaseDuration: Long,

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/MeasuredTask.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/MeasuredTask.kt
@@ -1,7 +1,9 @@
 package com.automattic.android.measure.models
 
+import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 
+@Serializable
 data class MeasuredTask(
     val name: String,
     val duration: Duration,

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
@@ -30,6 +30,7 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.MINUTES
 import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 import kotlin.io.path.exists
@@ -109,12 +110,14 @@ class MetricsReporter(
                     createDirectories()
                 }
                 resolve("build_data.json").apply {
+                    logger.info("Writing build data to ${absolutePathString()}")
                     if (!exists()) {
                         createFile()
                     }
                     writeText(Json.encodeToString(report.buildData))
                 }
                 resolve("execution_data.json").apply {
+                    logger.info("Writing execution data to ${absolutePathString()}")
                     if (!exists()) {
                         createFile()
                     }

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/MetricsReporter.kt
@@ -34,7 +34,7 @@ class MetricsReporter(
     private val authToken: Provider<String>,
 ) {
     suspend fun report(
-        report: Report,
+        report: InMemoryReport,
         gradleScanId: String?
     ) {
         @Suppress("TooGenericExceptionCaught")
@@ -112,7 +112,7 @@ class MetricsReporter(
         return client
     }
 
-    private fun logSlowTasks(report: Report) {
+    private fun logSlowTasks(report: InMemoryReport) {
         val slowTasks =
             report.executionData.tasks.sortedByDescending { it.duration }.chunked(atMostLoggedTasks)
                 .first()

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -1,11 +1,11 @@
 package com.automattic.android.measure.networking
 
-import com.automattic.android.measure.Report
+import com.automattic.android.measure.InMemoryReport
 import com.automattic.android.measure.models.MeasuredTask.State.EXECUTED
 import com.automattic.android.measure.models.MeasuredTask.State.IS_FROM_CACHE
 import com.automattic.android.measure.models.MeasuredTask.State.UP_TO_DATE
 
-fun Report.toAppsInfraPayload(gradleScanId: String?): GroupedAppsMetrics {
+fun InMemoryReport.toAppsInfraPayload(gradleScanId: String?): GroupedAppsMetrics {
     val projectKey = buildData.forProject.name.lowercase()
 
     val meta = mapOf(

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -132,7 +132,7 @@ class BuildTimePluginTest {
     ): GradleRunner {
         val projectDir = File("build/functionalTest")
         projectDir.mkdirs()
-        if(projectWithSendingScans) {
+        if (projectWithSendingScans) {
             projectDir.resolve("settings.gradle.kts").writeText(
                 """
             plugins {
@@ -146,7 +146,7 @@ class BuildTimePluginTest {
                     isUploadInBackground = false
                 }
             }
-            """.trimIndent()
+                """.trimIndent()
             )
         }
         projectDir.resolve("build.gradle.kts").writeText(

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -14,7 +14,8 @@ class BuildTimePluginTest {
         // given
         val runner = functionalTestRunner(
             enable = true,
-            attachGradleScanId = true
+            attachGradleScanId = true,
+            projectWithSendingScans = true
         )
 
         // when
@@ -124,14 +125,16 @@ class BuildTimePluginTest {
 
     private fun functionalTestRunner(
         enable: Boolean?,
+        projectWithSendingScans: Boolean = false,
         attachGradleScanId: Boolean,
         applyAppsMetricsToken: Boolean = true,
         vararg arguments: String,
     ): GradleRunner {
         val projectDir = File("build/functionalTest")
         projectDir.mkdirs()
-        projectDir.resolve("settings.gradle.kts").writeText(
-            """
+        if(projectWithSendingScans) {
+            projectDir.resolve("settings.gradle.kts").writeText(
+                """
             plugins {
                 id("com.gradle.enterprise") version "3.15.1"
             }
@@ -144,7 +147,8 @@ class BuildTimePluginTest {
                 }
             }
             """.trimIndent()
-        )
+            )
+        }
         projectDir.resolve("build.gradle.kts").writeText(
             """
             plugins {


### PR DESCRIPTION
Closes: #28 

### Motivation

1. Allow to test the expected output easier, without parsing output logs
2. For users: additional reports