### PR TITLE
Fix reporters not callable from groovy

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/InternalA8cCiReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/InternalA8cCiReporter.kt
@@ -31,6 +31,7 @@ object InternalA8cCiReporter {
     private val logger =
         GradleLogging.getLogger(InternalA8cCiReporter::class.java)
 
+    @JvmStatic
     fun reportBlocking(
         metricsReport: MetricsReport,
         projectName: String,

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/LocalMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/LocalMetricsReporter.kt
@@ -12,6 +12,8 @@ import kotlin.io.path.writeText
 
 object LocalMetricsReporter {
     private val logger = Logging.getLogger(LocalMetricsReporter::class.java)
+
+    @JvmStatic
     fun report(
         metricsReport: MetricsReport,
         buildDirPath: String,

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/SlowSlowTasksMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/SlowSlowTasksMetricsReporter.kt
@@ -8,6 +8,8 @@ import kotlin.time.Duration.Companion.seconds
 
 object SlowSlowTasksMetricsReporter {
     private val logger = Logging.getLogger(SlowSlowTasksMetricsReporter::class.java)
+
+    @JvmStatic
     fun report(
         metricsReport: MetricsReport
     ) {

--- a/measure-builds/src/test/java/com/automattic/android/measure/GroovyConfigurationTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/GroovyConfigurationTest.kt
@@ -1,0 +1,54 @@
+package com.automattic.android.measure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GroovyConfigurationTest {
+
+    @Test
+    fun `given a project configured via groovy, when running the build, the build succeeds and buildMetricsPrepared action is executed`() {
+        // given
+        // language=groovy
+        val groovyBuildGradle =
+            """
+            import com.automattic.android.measure.reporters.InternalA8cCiReporter
+            import com.automattic.android.measure.reporters.LocalMetricsReporter
+            import com.automattic.android.measure.reporters.SlowSlowTasksMetricsReporter 
+            import com.automattic.android.measure.reporters.MetricsReport
+
+            plugins {
+                id("com.automattic.android.measure-builds")
+            }
+            
+            measureBuilds {
+                enable = true
+                attachGradleScanId = false
+                buildMetricsPrepared { MetricsReport report -> 
+                    SlowSlowTasksMetricsReporter.report(report)
+                    LocalMetricsReporter.report(report, buildDir.absolutePath)
+                }
+            }
+            """
+        val projectDir = File("build/functionalTest").apply {
+            mkdirs()
+            resolve("settings.gradle").writeText("")
+            resolve("build.gradle").writeText(
+                groovyBuildGradle.trimIndent()
+            )
+        }
+
+        // when
+        val result = GradleRunner
+            .create()
+            .forwardOutput()
+            .withPluginClasspath()
+            .withArguments("help", "--stacktrace")
+            .withProjectDir(projectDir)
+            .build()
+
+        // then
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+    }
+}


### PR DESCRIPTION
### Description

Reporters, which are declared via static methods, to be available for Groovy scripts, must be annotated via `@JvmStatic` annotation. Otherwise, we get the following exception

```
No signature of method: static com.automattic.android.measure.reporters.SlowSlowTasksMetricsReporter.report() is applicable for argument types: (com.automattic.android.measure.reporters.InMemoryMetricsReporter$report$result$1) values: [com.automattic.android.measure.reporters.InMemoryMetricsReporter$report$result$1@924d05a]
```

Internally, the JVM bytecode difference, after applying `@JvmStatic` will change like this

```diff
-public final report(Lcom/automattic/android/measure/reporters/MetricsReport;)V
+public final static report(Lcom/automattic/android/measure/reporters/MetricsReport;)V
+@Lkotlin/jvm/JvmStatic;()
```

In #38 all tests pass as they're based on `*.gradle.kts` configuration (Kotlin Scripts can treat Kotlin `object` as static), that's why I've included `GroovyConfigurationTest`, to minimize the risk of a similar issue in the future.