### PR TITLE
Do not crash if `buildMetricsPreparedAction` null

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/InMemoryMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/InMemoryMetricsReporter.kt
@@ -2,11 +2,12 @@ package com.automattic.android.measure.reporters
 
 import com.automattic.android.measure.InMemoryReport
 import org.gradle.api.Action
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 
 object InMemoryMetricsReporter {
 
-    lateinit var buildMetricsPreparedAction: Property<Action<MetricsReport>>
+    var buildMetricsPreparedAction: Property<Action<MetricsReport>>? = null
 
     fun report(
         report: InMemoryReport,
@@ -18,6 +19,11 @@ object InMemoryMetricsReporter {
             override val gradleScanId: String?
                 get() = gradleScanId
         }
-        buildMetricsPreparedAction.get().execute(result)
+        if (buildMetricsPreparedAction == null) {
+            Logging.getLogger(InMemoryMetricsReporter::class.java).warn(
+                "buildMetricsPreparedAction is not set. Metrics will not be reported."
+            )
+        }
+        buildMetricsPreparedAction?.get()?.execute(result)
     }
 }


### PR DESCRIPTION
User reports that sometimes they experience `lateinit property buildMetricsPreparedAction has not been initialized` error, fixed by Android Studio/IntelliJ Gradle sync.

The root cause of this problem is not known at this moment, but it'll be better to warn client about it, rather than crashing the build.