### PR TITLE
Add task start and end timestamps

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildTaskService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildTaskService.kt
@@ -33,6 +33,8 @@ abstract class BuildTaskService :
                     MeasuredTask(
                         name = event.descriptor?.name.toString(),
                         duration = (event.result.endTime - event.result.startTime).milliseconds,
+                        startTimestamp = event.result.startTime,
+                        endTimestamp = event.result.endTime,
                         state = when {
                             result.isFromCache -> IS_FROM_CACHE
                             result.isUpToDate -> UP_TO_DATE

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/MeasuredTask.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/MeasuredTask.kt
@@ -7,6 +7,8 @@ import kotlin.time.Duration
 data class MeasuredTask(
     val name: String,
     val duration: Duration,
+    val startTimestamp: Long,
+    val endTimestamp: Long,
     val state: State
 ) {
     enum class State {

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -138,6 +138,7 @@ class BuildTimePluginTest {
             assertThat(executionData.executedTasks).hasSize(1).first().satisfies({ task ->
                 assertThat(task.name).isEqualTo(":help")
                 assertThat(task.state).isEqualTo(MeasuredTask.State.EXECUTED)
+                assertThat(task.endTimestamp - task.startTimestamp).isEqualTo(task.duration.inWholeMilliseconds)
             })
         }
     }


### PR DESCRIPTION
Hello there! 
I am planning to use this plugin for pushing build telemetry into our observability platform. However, in order to be able to build the tasks as a tree of spans, we need the start and end timestamps for them. So I am adding these fields to `MeasuredTask`.
Please let me know if there's any kind of improvement you'd like to see in this PR to make it shippable. Cheers!