### PR TITLE
Remote build cache stats

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -3,6 +3,7 @@ package com.automattic.android.measure
 import com.automattic.android.measure.lifecycle.BuildFinishedFlowAction
 import com.automattic.android.measure.lifecycle.BuildTaskService
 import com.automattic.android.measure.lifecycle.ConfigurationPhaseObserver
+import com.automattic.android.measure.lifecycle.RemoteBuildCacheStatsService
 import com.automattic.android.measure.providers.BuildDataProvider
 import com.automattic.android.measure.providers.UsernameProvider
 import com.automattic.android.measure.reporters.InMemoryMetricsReporter
@@ -16,7 +17,9 @@ import org.gradle.api.flow.FlowProviders
 import org.gradle.api.flow.FlowScope
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.buildevents.BuildStartedTime
+import org.gradle.internal.extensions.core.serviceOf
 import org.gradle.invocation.DefaultGradle
 import javax.inject.Inject
 import kotlin.time.ExperimentalTime
@@ -55,6 +58,11 @@ class BuildTimePlugin @Inject constructor(
                 )
             }
         }
+
+        val listenerService =
+            project.gradle.sharedServices.registerIfAbsent("listener-service", RemoteBuildCacheStatsService::class.java)
+        val buildEventListenerRegistry: BuildEventListenerRegistryInternal = project.serviceOf()
+        buildEventListenerRegistry.onOperationCompletion(listenerService)
 
         prepareBuildTaskService(project)
         prepareBuildScanListener(project, extension, metricsDispatcher)

--- a/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/BuildTimePlugin.kt
@@ -59,13 +59,16 @@ class BuildTimePlugin @Inject constructor(
             }
         }
 
+        prepareRemoteBuildCacheListener(project)
+        prepareBuildTaskService(project)
+        prepareBuildScanListener(project, extension, metricsDispatcher)
+    }
+
+    private fun prepareRemoteBuildCacheListener(project: Project) {
         val listenerService =
             project.gradle.sharedServices.registerIfAbsent("listener-service", RemoteBuildCacheStatsService::class.java)
         val buildEventListenerRegistry: BuildEventListenerRegistryInternal = project.serviceOf()
         buildEventListenerRegistry.onOperationCompletion(listenerService)
-
-        prepareBuildTaskService(project)
-        prepareBuildScanListener(project, extension, metricsDispatcher)
     }
 
     private fun prepareBuildData(

--- a/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
@@ -2,6 +2,7 @@ package com.automattic.android.measure
 
 import com.automattic.android.measure.models.BuildData
 import com.automattic.android.measure.models.ExecutionData
+import com.automattic.android.measure.models.RemoteBuildCacheData
 
 object InMemoryReport {
     private var buildDataStore: BuildData? = null
@@ -20,4 +21,6 @@ object InMemoryReport {
 
     val executionData: ExecutionData
         get() = executionDataStore ?: throw NullPointerException("Execution data must not be null")
+
+    var remoteBuildCacheData: RemoteBuildCacheData = RemoteBuildCacheData()
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/InMemoryReport.kt
@@ -22,5 +22,5 @@ object InMemoryReport {
     val executionData: ExecutionData
         get() = executionDataStore ?: throw NullPointerException("Execution data must not be null")
 
-    var remoteBuildCacheData: RemoteBuildCacheData = RemoteBuildCacheData()
+    var remoteBuildCacheData: RemoteBuildCacheData? = null
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
@@ -1,0 +1,67 @@
+package com.automattic.android.measure.lifecycle
+
+import com.automattic.android.measure.InMemoryReport
+import com.automattic.android.measure.models.OriginExecutionTaskData
+import com.automattic.android.measure.models.RemoteBuildCacheData
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.caching.internal.controller.operations.LoadOperationDetails
+import org.gradle.caching.internal.operations.BuildCacheRemoteLoadBuildOperationType
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.BuildOperationListener
+import org.gradle.internal.operations.OperationFinishEvent
+import org.gradle.internal.operations.OperationIdentifier
+import org.gradle.internal.operations.OperationProgressEvent
+import org.gradle.internal.operations.OperationStartEvent
+
+abstract class RemoteBuildCacheStatsService : BuildService<BuildServiceParameters.None>,
+    BuildOperationListener {
+
+    init {
+        InMemoryReport.remoteBuildCacheData = RemoteBuildCacheData()
+    }
+
+    override fun started(
+        buildOperation: BuildOperationDescriptor,
+        startEvent: OperationStartEvent,
+    ) {
+    }
+
+    override fun progress(
+        operationIdentifier: OperationIdentifier,
+        progressEvent: OperationProgressEvent,
+    ) {
+    }
+
+    override fun finished(
+        buildOperation: BuildOperationDescriptor,
+        finishEvent: OperationFinishEvent,
+    ) {
+        if (
+            (finishEvent.result is BuildCacheRemoteLoadBuildOperationType.Result) &&
+            (finishEvent.result as BuildCacheRemoteLoadBuildOperationType.Result).isHit
+        ) {
+            val details = buildOperation.details as LoadOperationDetails
+
+            InMemoryReport.remoteBuildCacheData.remoteLoadTimes[details.cacheKey] =
+                finishEvent.endTime - finishEvent.startTime
+        }
+        if (finishEvent.result is ExecuteTaskBuildOperationType.Result) {
+            val result = finishEvent.result as ExecuteTaskBuildOperationType.Result
+
+            result.takeIf { !it.isIncremental }?.let {
+                result.originBuildCacheKeyBytes?.let { HashCode.fromBytes(it) }
+                    ?.toString() to result.originExecutionTime
+            }?.let { (cacheKey, executionTime) ->
+                if (cacheKey != null && executionTime != null) {
+                    InMemoryReport.remoteBuildCacheData.originExecutions[cacheKey] = OriginExecutionTaskData(
+                        name = buildOperation.name,
+                        executionTime = executionTime,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
@@ -1,6 +1,7 @@
 package com.automattic.android.measure.lifecycle
 
 import com.automattic.android.measure.InMemoryReport
+import com.automattic.android.measure.models.DownloadEvent
 import com.automattic.android.measure.models.OriginExecutionTaskData
 import com.automattic.android.measure.models.RemoteBuildCacheData
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
@@ -34,15 +35,18 @@ abstract class RemoteBuildCacheStatsService :
         finishEvent: OperationFinishEvent,
     ) {
         if (
-            (finishEvent.result is BuildCacheRemoteLoadBuildOperationType.Result) &&
-            (finishEvent.result as BuildCacheRemoteLoadBuildOperationType.Result).isHit
+            (finishEvent.result is BuildCacheRemoteLoadBuildOperationType.Result)
         ) {
-            val details = buildOperation.details as LoadOperationDetails
+            val result = finishEvent.result as BuildCacheRemoteLoadBuildOperationType.Result
 
-            InMemoryReport.remoteBuildCacheData?.remoteLoadTimes?.set(
-                details.cacheKey,
-                finishEvent.endTime - finishEvent.startTime
-            )
+            if (result.isHit) {
+                val details = buildOperation.details as LoadOperationDetails
+
+                InMemoryReport.remoteBuildCacheData?.remoteLoads?.set(
+                    details.cacheKey,
+                    DownloadEvent(finishEvent.startTime, finishEvent.endTime, result.archiveSize)
+                )
+            }
         }
 
         if (finishEvent.result is BuildCacheArchiveUnpackBuildOperationType.Result) {

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
@@ -16,24 +16,17 @@ import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 
-abstract class RemoteBuildCacheStatsService : BuildService<BuildServiceParameters.None>,
+abstract class RemoteBuildCacheStatsService :
+    BuildService<BuildServiceParameters.None>,
     BuildOperationListener {
 
     init {
         InMemoryReport.remoteBuildCacheData = RemoteBuildCacheData()
     }
 
-    override fun started(
-        buildOperation: BuildOperationDescriptor,
-        startEvent: OperationStartEvent,
-    ) {
-    }
+    override fun started(buildOperation: BuildOperationDescriptor, startEvent: OperationStartEvent) = Unit
 
-    override fun progress(
-        operationIdentifier: OperationIdentifier,
-        progressEvent: OperationProgressEvent,
-    ) {
-    }
+    override fun progress(operationIdentifier: OperationIdentifier, progressEvent: OperationProgressEvent) = Unit
 
     override fun finished(
         buildOperation: BuildOperationDescriptor,

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
@@ -45,8 +45,10 @@ abstract class RemoteBuildCacheStatsService : BuildService<BuildServiceParameter
         ) {
             val details = buildOperation.details as LoadOperationDetails
 
-            InMemoryReport.remoteBuildCacheData.remoteLoadTimes[details.cacheKey] =
+            InMemoryReport.remoteBuildCacheData?.remoteLoadTimes?.set(
+                details.cacheKey,
                 finishEvent.endTime - finishEvent.startTime
+            )
         }
         if (finishEvent.result is ExecuteTaskBuildOperationType.Result) {
             val result = finishEvent.result as ExecuteTaskBuildOperationType.Result
@@ -56,9 +58,12 @@ abstract class RemoteBuildCacheStatsService : BuildService<BuildServiceParameter
                     ?.toString() to result.originExecutionTime
             }?.let { (cacheKey, executionTime) ->
                 if (cacheKey != null && executionTime != null) {
-                    InMemoryReport.remoteBuildCacheData.originExecutions[cacheKey] = OriginExecutionTaskData(
-                        name = buildOperation.name,
-                        executionTime = executionTime,
+                    InMemoryReport.remoteBuildCacheData?.originExecutions?.set(
+                        cacheKey,
+                        OriginExecutionTaskData(
+                            name = buildOperation.name,
+                            executionTime = executionTime,
+                        )
                     )
                 }
             }

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/RemoteBuildCacheStatsService.kt
@@ -7,6 +7,7 @@ import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.caching.internal.controller.operations.LoadOperationDetails
+import org.gradle.caching.internal.operations.BuildCacheArchiveUnpackBuildOperationType
 import org.gradle.caching.internal.operations.BuildCacheRemoteLoadBuildOperationType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.operations.BuildOperationDescriptor
@@ -43,6 +44,16 @@ abstract class RemoteBuildCacheStatsService :
                 finishEvent.endTime - finishEvent.startTime
             )
         }
+
+        if (finishEvent.result is BuildCacheArchiveUnpackBuildOperationType.Result) {
+            val details = buildOperation.details as BuildCacheArchiveUnpackBuildOperationType.Details
+
+            InMemoryReport.remoteBuildCacheData?.unpackTimes?.set(
+                details.cacheKey,
+                finishEvent.endTime - finishEvent.startTime
+            )
+        }
+
         if (finishEvent.result is ExecuteTaskBuildOperationType.Result) {
             val result = finishEvent.result as ExecuteTaskBuildOperationType.Result
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/logging/Emojis.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/logging/Emojis.kt
@@ -5,4 +5,5 @@ object Emojis {
     const val FAILURE_ICON = "\u274C"
     const val WAITING_ICON = "\u23F3"
     const val TURTLE_ICON = "\uD83D\uDC22"
+    const val ROCKET_ICON = "\uD83D\uDE80"
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -41,7 +41,7 @@ data class RemoteBuildCacheData(
 
     /**
      * Maps cache keys to avoidance values, representing the estimated time saved by using the remote build cache.
-     * The avoidance value is calculated by subtracting the time required to retrieve the task output from the remote cache
+     * The avoidance value is calculated by subtracting the remote cache retrieval time
      * from the original execution time.
      */
     val avoidances: List<Pair<String, Duration>>

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -36,7 +36,8 @@ data class ExecutionData(
 @Serializable
 data class RemoteBuildCacheData(
     val originExecutions: MutableMap<String, OriginExecutionTaskData> = hashMapOf(),
-    val remoteLoadTimes: MutableMap<String, Long> = hashMapOf()
+    val remoteLoadTimes: MutableMap<String, Long> = hashMapOf(),
+    val unpackTimes: MutableMap<String, Long> = hashMapOf()
 ) {
 
     /**
@@ -47,8 +48,9 @@ data class RemoteBuildCacheData(
     val avoidances: List<Pair<String, Duration>>
         get() = originExecutions.mapNotNull {
             val remoteLoadTime = remoteLoadTimes[it.key]
-            if (remoteLoadTime != null) {
-                val timeAvoidance = it.value.executionTime - remoteLoadTime
+            val unpackTime = unpackTimes[it.key]
+            if (remoteLoadTime != null && unpackTime != null) {
+                val timeAvoidance = it.value.executionTime - remoteLoadTime - unpackTime
                 it.value.name to timeAvoidance.milliseconds
             } else {
                 null

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -1,6 +1,8 @@
 package com.automattic.android.measure.models
 
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Be extra careful when adding new parameters to build data. It's resolved during configuration
@@ -35,7 +37,33 @@ data class ExecutionData(
 data class RemoteBuildCacheData(
     val originExecutions: MutableMap<String, OriginExecutionTaskData> = hashMapOf(),
     val remoteLoadTimes: MutableMap<String, Long> = hashMapOf()
-)
+) {
+
+    /**
+     * Maps cache keys to avoidance values, representing the estimated time saved by using the remote build cache.
+     * The avoidance value is calculated by subtracting the time required to retrieve the task output from the remote cache
+     * from the original execution time.
+     */
+    val avoidances: List<Pair<String, Duration>>
+        get() = originExecutions.mapNotNull {
+            val remoteLoadTime = remoteLoadTimes[it.key]
+            if (remoteLoadTime != null) {
+                val timeAvoidance = it.value.executionTime - remoteLoadTime
+                it.value.name to timeAvoidance.milliseconds
+            } else {
+                null
+            }
+        }.sortedByDescending { it.second }
+
+    /**
+     * The total estimated time saved across all tasks by using the remote build cache.
+     * Calculated as the sum of all individual avoidance values in milliseconds.
+     *
+     * Note: This calculation assumes sequential execution and does not account for parallelization.
+     */
+    val totalSavings
+        get() = avoidances.sumOf { it.second.inWholeMilliseconds }.milliseconds
+}
 
 @Serializable
 data class OriginExecutionTaskData(

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -1,6 +1,8 @@
 package com.automattic.android.measure.models
 
+import com.automattic.android.measure.tools.IntervalMeasurer
 import kotlinx.serialization.Serializable
+import java.util.Locale
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -36,9 +38,11 @@ data class ExecutionData(
 @Serializable
 data class RemoteBuildCacheData(
     val originExecutions: MutableMap<String, OriginExecutionTaskData> = hashMapOf(),
-    val remoteLoadTimes: MutableMap<String, Long> = hashMapOf(),
+    val remoteLoads: MutableMap<String, DownloadEvent> = hashMapOf(),
     val unpackTimes: MutableMap<String, Long> = hashMapOf()
 ) {
+    val remoteLoadTimes: Map<String, Long>
+        get() = remoteLoads.mapValues { it.value.endTime - it.value.startTime }
 
     /**
      * Maps cache keys to avoidance values, representing the estimated time saved by using the remote build cache.
@@ -65,12 +69,56 @@ data class RemoteBuildCacheData(
      */
     val totalSavings
         get() = avoidances.sumOf { it.second.inWholeMilliseconds }.milliseconds
+
+    private val clockTimeDownloadDuration: Duration
+        get() = remoteLoads.values.toList().map { it.startTime to it.endTime }
+            .let { IntervalMeasurer.findTotalTime(it) }.milliseconds
+
+    private val totalArchiveSize: Long
+        get() = remoteLoads.values.sumOf { it.archiveSize }
+
+    /**
+     * Estimates the download speed while considering task parallelization.
+     * This calculation does not account for any pauses between task executions.
+     *
+     * The estimation is based on the time between the start of the first fetch
+     * and the completion of the last fetch. The total fetched artifact size is
+     * divided by this duration to approximate the download speed.
+     *
+     * Note: This is an estimated value and may not reflect the exact download speed,
+     * but it still provides a useful approximation. Inspired by
+     * https://github.com/runningcode/gradle-doctor/blob/2e61538beeda9d8859e20861e18b227508edfd6f/doctor-plugin/src/main/java/com/osacky/doctor/BuildCacheConnectionMeasurer.kt#L15
+     */
+    @Suppress("MagicNumber")
+    val estimatedDownloadSpeed: String?
+        get() {
+            val bytesPerKiB = 1024
+            val bytesPerMiB = bytesPerKiB * 1024
+
+            val speedBps = if (clockTimeDownloadDuration.inWholeMilliseconds > 0) {
+                (totalArchiveSize.toDouble() / clockTimeDownloadDuration.inWholeMilliseconds) * 1000
+            } else {
+                return null
+            }
+
+            return when {
+                speedBps >= bytesPerMiB -> String.format(Locale.US, "%.2f MiB/s", speedBps / bytesPerMiB)
+                else -> String.format(Locale.US, "%.2f KiB/s", speedBps / bytesPerKiB)
+            }
+        }
 }
 
 @Serializable
 data class OriginExecutionTaskData(
     val name: String,
     val executionTime: Long
+)
+
+@Serializable
+data class DownloadEvent(
+    val startTime: Long,
+    val endTime: Long,
+    val archiveSize: Long
 )
 
 enum class Environment {

--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -31,6 +31,18 @@ data class ExecutionData(
     val configurationPhaseDuration: Long,
 )
 
+@Serializable
+data class RemoteBuildCacheData(
+    val originExecutions: MutableMap<String, OriginExecutionTaskData> = hashMapOf(),
+    val remoteLoadTimes: MutableMap<String, Long> = hashMapOf()
+)
+
+@Serializable
+data class OriginExecutionTaskData(
+    val name: String,
+    val executionTime: Long
+)
+
 enum class Environment {
     IDE,
     CI,

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -41,8 +41,9 @@ fun InMemoryReport.toAppsMetricsPayload(
     }
 
     val remoteBuildCacheMetrics = mapOf(
-        "remote-build-cache-total-savings" to remoteBuildCacheData?.totalSavings?.inWholeMilliseconds?.toString()
-    ).filterValues { it != null }.mapValues { it.value.orEmpty() }
+        "total-savings" to remoteBuildCacheData?.totalSavings?.inWholeMilliseconds?.toString(),
+        "avg-speed" to remoteBuildCacheData?.estimatedDownloadSpeed
+    ).filterValues { it != null }.mapKeys { "remote-build-cache-$it" }.mapValues { it.value.orEmpty() }
 
     return GroupedAppsMetrics(
         meta = meta.map { (key, value) ->

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -40,6 +40,10 @@ fun InMemoryReport.toAppsMetricsPayload(
         "task-${it.name}" to it.duration.inWholeMilliseconds.toString()
     }
 
+    val remoteBuildCacheMetrics = mapOf(
+        "remote-build-cache-total-savings" to remoteBuildCacheData?.totalSavings?.inWholeMilliseconds?.toString()
+    ).filterValues { it != null }.mapValues { it.value.orEmpty() }
+
     return GroupedAppsMetrics(
         meta = meta.map { (key, value) ->
             AppsMetric(
@@ -48,7 +52,7 @@ fun InMemoryReport.toAppsMetricsPayload(
                 value = value.ifBlank { "null" }
             )
         },
-        metrics = (metrics + tasks).map { (key, value) ->
+        metrics = (metrics + tasks + remoteBuildCacheMetrics).map { (key, value) ->
             AppsMetric(
                 name = "$projectKey-$key",
                 // Apps Metrics doesn't allow metric value to be empty

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -43,7 +43,7 @@ fun InMemoryReport.toAppsMetricsPayload(
     val remoteBuildCacheMetrics = mapOf(
         "total-savings" to remoteBuildCacheData?.totalSavings?.inWholeMilliseconds?.toString(),
         "avg-speed" to remoteBuildCacheData?.estimatedDownloadSpeed
-    ).filterValues { it != null }.mapKeys { "remote-build-cache-$it" }.mapValues { it.value.orEmpty() }
+    ).filterValues { it != null }.mapKeys { "remote-build-cache-${it.key}" }.mapValues { it.value.orEmpty() }
 
     return GroupedAppsMetrics(
         meta = meta.map { (key, value) ->

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
@@ -1,11 +1,15 @@
 package com.automattic.android.measure.reporters
 
+import com.automattic.android.measure.logging.Emojis
 import org.gradle.api.logging.Logging
+import java.util.Locale
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 object RemoteBuildCacheMetricsReporter {
 
     private val logger = Logging.getLogger(RemoteBuildCacheMetricsReporter::class.java)
+    private val LOG_SAVINGS_THRESHOLD = 500.milliseconds
 
     @JvmStatic
     fun report(metricsReporter: MetricsReport) {
@@ -19,9 +23,18 @@ object RemoteBuildCacheMetricsReporter {
             } else {
                 null
             }
+        }.sortedByDescending { it.second }
+
+        val totalSavings = avoidanceMap.sumOf { it.second.inWholeMilliseconds }.milliseconds
+
+        if (totalSavings > LOG_SAVINGS_THRESHOLD) {
+            logger.lifecycle("\n${Emojis.ROCKET_ICON} Sum of estimated remote cache savings: $totalSavings (not actual saved build duration). Top savings:")
+            logger.lifecycle(String.format(Locale.US, "%-15s %s", "Saved", "Task"))
+            avoidanceMap.take(3).forEach { (task, avoidance) ->
+                logger.lifecycle(String.format("%-15s %s", avoidance, task))
+            }
+        } else if (totalSavings < Duration.ZERO) {
+            logger.lifecycle("\n${Emojis.FAILURE_ICON} It's estimated that remote cache added ${totalSavings.absoluteValue} to the build. Assert you have stable internet connection.")
         }
-
-        logger.lifecycle(avoidanceMap.toString())
-
     }
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
@@ -1,0 +1,27 @@
+package com.automattic.android.measure.reporters
+
+import org.gradle.api.logging.Logging
+import kotlin.time.Duration.Companion.milliseconds
+
+object RemoteBuildCacheMetricsReporter {
+
+    private val logger = Logging.getLogger(RemoteBuildCacheMetricsReporter::class.java)
+
+    @JvmStatic
+    fun report(metricsReporter: MetricsReport) {
+        val (originExecutionTimes, remoteLoadTimes) = metricsReporter.report.remoteBuildCacheData
+
+        val avoidanceMap = originExecutionTimes.mapNotNull {
+            val remoteLoadTime = remoteLoadTimes[it.key]
+            if (remoteLoadTime != null) {
+                val timeAvoidance = it.value.executionTime - remoteLoadTime
+                it.value.name to timeAvoidance.milliseconds
+            } else {
+                null
+            }
+        }
+
+        logger.lifecycle(avoidanceMap.toString())
+
+    }
+}

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
@@ -17,10 +17,12 @@ object RemoteBuildCacheMetricsReporter {
         metricsReporter.report.remoteBuildCacheData?.let { data ->
             val totalSavings = data.totalSavings
             val avoidances = data.avoidances
+            val estimatedDownloadSpeed = data.estimatedDownloadSpeed
 
             if (totalSavings > LOG_SAVINGS_THRESHOLD) {
                 logger.lifecycle(
-                    "\n${Emojis.ROCKET_ICON} Sum of estimated remote cache savings: $totalSavings. Top savings:"
+                    "\n${Emojis.ROCKET_ICON} Sum of estimated remote cache savings: $totalSavings. " +
+                        "Average speed was $estimatedDownloadSpeed. Top savings:"
                 )
                 logger.lifecycle(String.format(Locale.US, "%-15s %s", "Saved", "Task"))
                 avoidances.take(MAX_TOP_AVOIDANCES).forEach { (task, avoidance) ->
@@ -29,7 +31,8 @@ object RemoteBuildCacheMetricsReporter {
             } else if (totalSavings < Duration.ZERO) {
                 logger.lifecycle(
                     "\n${Emojis.FAILURE_ICON} Remote cache is estimated to have added" +
-                        " ${totalSavings.absoluteValue} to the build time. Check your network performance."
+                        " ${totalSavings.absoluteValue} to the build time. Check your network performance. " +
+                        "Average speed was $estimatedDownloadSpeed."
                 )
             }
         }

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
@@ -10,25 +10,28 @@ object RemoteBuildCacheMetricsReporter {
 
     private val logger = Logging.getLogger(RemoteBuildCacheMetricsReporter::class.java)
     private val LOG_SAVINGS_THRESHOLD = 500.milliseconds
+    private const val MAX_TOP_AVOIDANCES = 3
 
     @JvmStatic
     fun report(metricsReporter: MetricsReport) {
-
         metricsReporter.report.remoteBuildCacheData?.let { data ->
             val totalSavings = data.totalSavings
             val avoidances = data.avoidances
 
             if (totalSavings > LOG_SAVINGS_THRESHOLD) {
-                logger.lifecycle("\n${Emojis.ROCKET_ICON} Sum of estimated remote cache savings: $totalSavings (not actual saved build duration). Top savings:")
+                logger.lifecycle(
+                    "\n${Emojis.ROCKET_ICON} Sum of estimated remote cache savings: $totalSavings. Top savings:"
+                )
                 logger.lifecycle(String.format(Locale.US, "%-15s %s", "Saved", "Task"))
-                avoidances.take(3).forEach { (task, avoidance) ->
-                    logger.lifecycle(String.format("%-15s %s", avoidance, task))
+                avoidances.take(MAX_TOP_AVOIDANCES).forEach { (task, avoidance) ->
+                    logger.lifecycle(String.format(Locale.US, "%-15s %s", avoidance, task))
                 }
             } else if (totalSavings < Duration.ZERO) {
-                logger.lifecycle("\n${Emojis.FAILURE_ICON} It's estimated that remote cache added ${totalSavings.absoluteValue} to the build. Assert you have stable internet connection.")
+                logger.lifecycle(
+                    "\n${Emojis.FAILURE_ICON} Remote cache is estimated to have added" +
+                        " ${totalSavings.absoluteValue} to the build time. Check your network performance."
+                )
             }
-
         }
-
     }
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/tools/IntervalMeasurer.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/tools/IntervalMeasurer.kt
@@ -1,0 +1,28 @@
+package com.automattic.android.measure.tools
+
+import kotlin.math.max
+
+object IntervalMeasurer {
+    /**
+     * Find the total time elapsed based on the union of the time intervals.
+     * This is based on the following Stackoverflow answer but converted to Kotlin:
+     * https://codereview.stackexchange.com/questions/126906/finding-the-total-time-elapsed-in-the-union-of-time-intervals
+     */
+    fun findTotalTime(intervals: List<Pair<Long, Long>>): Long {
+        if (intervals.isEmpty()) {
+            return 0L
+        }
+        val sorted = intervals.sortedBy { it.first }
+        var totalTime = 0L
+        var currentEnd = intervals[0].first
+
+        sorted.forEach { interval ->
+            if (interval.second > currentEnd) {
+                totalTime += interval.second - max(interval.first, currentEnd)
+                currentEnd = interval.second
+            }
+        }
+
+        return totalTime
+    }
+}

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginTest.kt
@@ -173,6 +173,8 @@ class BuildTimePluginTest {
                         }
                     """.trimIndent()
                 )
+            } else {
+                resolve("settings.gradle.kts").writeText("")
             }
             resolve("build.gradle.kts").writeText(
                 """


### PR DESCRIPTION
### Description

This PR introduces getting data and reporting statistics about remote build cache usage in the build. It uses `internal` Gradle's APIs, as I haven't found any other way to accomplish these goals.

A new local (CMD) reporter is available: `RemoteBuildCacheMetricsReporter`.

New metrics are:
- `avoidances`: list of tasks with values of how much remote build cache saved on this task (`original execution time` -`fetching` - `unpacking`)
- `totalSaving`: sum of the above
- `estimatedDownloadSpeed`: estimated fetch speed, taking into account parallelization. 

Values of `avoidances` are in sync with what you can see in Gradle Build Scan, e.g. (look at `2m 58.852s`)

| Gradle Build Scan | Measure Builds Plugin | 
| --- | --- | 
| ![image](https://github.com/user-attachments/assets/cc5737fa-978e-47bd-b161-5944c5f3a25e) | ![image](https://github.com/user-attachments/assets/4e62dcba-bea9-4666-a7a2-abb2e9931906) |



