### PR TITLE
Drop attaching Gradle Scans ids to reports

### DIFF
--- a/measure-builds/build.gradle.kts
+++ b/measure-builds/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 
 dependencies {
     implementation(gradleApi())
-    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.15.1")
 
     val ktor = "3.1.1"
     implementation("io.ktor:ktor-client-core:$ktor")

--- a/measure-builds/src/main/java/com/automattic/android/measure/MeasureBuildsExtension.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/MeasureBuildsExtension.kt
@@ -38,15 +38,4 @@ abstract class MeasureBuildsExtension(project: Project) {
     fun onBuildMetricsReadyListener(action: Action<MetricsReport>) {
         buildMetricsReadyAction.set(action)
     }
-
-    /**
-     * If `true`, then the metrics will be sent at build finish,
-     * orchestrated by Gradle Enterprise plugin, attaching
-     * Gradle Build Scan id to metrics.
-     *
-     * If `false`, then metrics will be sent at build finish by
-     * @see [com.automattic.android.measure.lifecycle.BuildFinishedFlowAction].
-     */
-    val attachGradleScanId: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(false)
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/lifecycle/BuildFinishedFlowAction.kt
@@ -29,9 +29,6 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
         @get:Input
         val buildWorkResult: Property<Provider<BuildWorkResult>>
 
-        @get:Input
-        val attachGradleScanId: Property<Boolean>
-
         @get:ServiceReference
         val buildTaskService: Property<BuildTaskService>
 
@@ -64,12 +61,6 @@ class BuildFinishedFlowAction : FlowAction<BuildFinishedFlowAction.Parameters> {
         )
 
         InMemoryReport.setExecutionData(executionData)
-
-        if (parameters.attachGradleScanId.get() == false) {
-            InMemoryMetricsReporter.report(
-                report = InMemoryReport,
-                gradleScanId = null
-            )
-        }
+        InMemoryMetricsReporter.report(InMemoryReport)
     }
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -5,10 +5,7 @@ import com.automattic.android.measure.models.MeasuredTask.State.EXECUTED
 import com.automattic.android.measure.models.MeasuredTask.State.IS_FROM_CACHE
 import com.automattic.android.measure.models.MeasuredTask.State.UP_TO_DATE
 
-fun InMemoryReport.toAppsMetricsPayload(
-    projectKey: String,
-    gradleScanId: String?
-): GroupedAppsMetrics {
+fun InMemoryReport.toAppsMetricsPayload(projectKey: String): GroupedAppsMetrics {
     val meta = mapOf(
         "user" to buildData.user,
         "project" to projectKey,
@@ -32,7 +29,6 @@ fun InMemoryReport.toAppsMetricsPayload(
         "included-builds" to buildData.includedBuildsNames.joinToString(separator = ",")
             .ifEmpty { "none" },
         "build-finished-at" to executionData.buildFinishedTimestamp.toString(),
-        "gradle-scan-id" to gradleScanId.orEmpty(),
         "configuration-duration" to executionData.configurationPhaseDuration.toString()
     )
 

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/InMemoryMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/InMemoryMetricsReporter.kt
@@ -9,15 +9,10 @@ object InMemoryMetricsReporter {
 
     var buildMetricsPreparedAction: Property<Action<MetricsReport>>? = null
 
-    fun report(
-        report: InMemoryReport,
-        gradleScanId: String?
-    ) {
+    fun report(report: InMemoryReport) {
         val result = object : MetricsReport {
             override val report: InMemoryReport
                 get() = report
-            override val gradleScanId: String?
-                get() = gradleScanId
         }
         if (buildMetricsPreparedAction == null) {
             Logging.getLogger(InMemoryMetricsReporter::class.java).warn(

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/InternalA8cCiReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/InternalA8cCiReporter.kt
@@ -52,7 +52,7 @@ object InternalA8cCiReporter {
         authToken: String?,
     ) {
         val report = metricsReport.report
-        val payload = report.toAppsMetricsPayload(projectName, metricsReport.gradleScanId)
+        val payload = report.toAppsMetricsPayload(projectName)
         @Suppress("TooGenericExceptionCaught")
         try {
             if (authToken.isNullOrBlank()) {

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/MetricsReport.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/MetricsReport.kt
@@ -4,5 +4,4 @@ import com.automattic.android.measure.InMemoryReport
 
 interface MetricsReport {
     val report: InMemoryReport
-    val gradleScanId: String?
 }

--- a/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginConfigurationCacheTests.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/BuildTimePluginConfigurationCacheTests.kt
@@ -99,7 +99,6 @@ class BuildTimePluginConfigurationCacheTests {
             val buildPathProperty = project.layout.buildDirectory.map { it.asFile.path }
             measureBuilds {
                 enable.set(true)
-                attachGradleScanId.set(false)
                 onBuildMetricsReadyListener {
                     val buildPath = buildPathProperty.get()
                     com.automattic.android.measure.reporters.LocalMetricsReporter.report(this, buildPath)

--- a/measure-builds/src/test/java/com/automattic/android/measure/GroovyConfigurationTest.kt
+++ b/measure-builds/src/test/java/com/automattic/android/measure/GroovyConfigurationTest.kt
@@ -24,7 +24,6 @@ class GroovyConfigurationTest {
             
             measureBuilds {
                 enable = true
-                attachGradleScanId = false
                 onBuildMetricsReadyListener { MetricsReport report -> 
                     SlowSlowTasksMetricsReporter.report(report)
                     LocalMetricsReporter.report(report, buildDir.absolutePath)


### PR DESCRIPTION
The support for this feature would require migration to use new Develocity API. As possibility of browsing scans of single builds happened to be not used at all at Automattic, I think it's not really that useful to justify working on the migration. Instead, this commit simply removes feature of Gradle Scans ids.

Closes: #52 