### PR TITLE
fix: return bytes per second in `RemoteBuildCacheData` instead of formatted kib/s or mib/s

### DIFF
--- a/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/models/BuildData.kt
@@ -2,7 +2,6 @@ package com.automattic.android.measure.models
 
 import com.automattic.android.measure.tools.IntervalMeasurer
 import kotlinx.serialization.Serializable
-import java.util.Locale
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -89,21 +88,12 @@ data class RemoteBuildCacheData(
      * but it still provides a useful approximation. Inspired by
      * https://github.com/runningcode/gradle-doctor/blob/2e61538beeda9d8859e20861e18b227508edfd6f/doctor-plugin/src/main/java/com/osacky/doctor/BuildCacheConnectionMeasurer.kt#L15
      */
-    @Suppress("MagicNumber")
-    val estimatedDownloadSpeed: String?
+    val estimatedDownloadSpeed: Double?
         get() {
-            val bytesPerKiB = 1024
-            val bytesPerMiB = bytesPerKiB * 1024
-
-            val speedBps = if (clockTimeDownloadDuration.inWholeMilliseconds > 0) {
-                (totalArchiveSize.toDouble() / clockTimeDownloadDuration.inWholeMilliseconds) * 1000
+            return if (clockTimeDownloadDuration.inWholeMilliseconds > 0) {
+                totalArchiveSize.toDouble() / clockTimeDownloadDuration.inWholeSeconds
             } else {
-                return null
-            }
-
-            return when {
-                speedBps >= bytesPerMiB -> String.format(Locale.US, "%.2f MiB/s", speedBps / bytesPerMiB)
-                else -> String.format(Locale.US, "%.2f KiB/s", speedBps / bytesPerKiB)
+                null
             }
         }
 }

--- a/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/networking/ToAppsInfraPayload.kt
@@ -42,7 +42,7 @@ fun InMemoryReport.toAppsMetricsPayload(
 
     val remoteBuildCacheMetrics = mapOf(
         "total-savings" to remoteBuildCacheData?.totalSavings?.inWholeMilliseconds?.toString(),
-        "avg-speed" to remoteBuildCacheData?.estimatedDownloadSpeed
+        "avg-speed" to remoteBuildCacheData?.estimatedDownloadSpeed?.toString()
     ).filterValues { it != null }.mapKeys { "remote-build-cache-${it.key}" }.mapValues { it.value.orEmpty() }
 
     return GroupedAppsMetrics(

--- a/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
+++ b/measure-builds/src/main/java/com/automattic/android/measure/reporters/RemoteBuildCacheMetricsReporter.kt
@@ -17,7 +17,7 @@ object RemoteBuildCacheMetricsReporter {
         metricsReporter.report.remoteBuildCacheData?.let { data ->
             val totalSavings = data.totalSavings
             val avoidances = data.avoidances
-            val estimatedDownloadSpeed = data.estimatedDownloadSpeed
+            val estimatedDownloadSpeed = data.estimatedDownloadSpeed?.let { formatAverageSpeed(it) }
 
             if (totalSavings > LOG_SAVINGS_THRESHOLD) {
                 logger.lifecycle(
@@ -35,6 +35,17 @@ object RemoteBuildCacheMetricsReporter {
                         "Average speed was $estimatedDownloadSpeed."
                 )
             }
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun formatAverageSpeed(speedBps: Double): String {
+        val bytesPerKiB = 1024
+        val bytesPerMiB = bytesPerKiB * 1024
+
+        return when {
+            speedBps >= bytesPerMiB -> String.format(Locale.US, "%.2f MiB/s", speedBps / bytesPerMiB)
+            else -> String.format(Locale.US, "%.2f KiB/s", speedBps / bytesPerKiB)
         }
     }
 }


### PR DESCRIPTION
Having a formatted value in metrics is not good, as it's harder for any metrics system to interpret disambiguity (sometimes kib/s, sometimes mib/s).

Formatting has been moved to `RemoteBuildCacheMetricsReporter`