### PR TITLE
chore: use specific-version labels for SHA-pinned actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Checkout latest code
         uses: actions/checkout@v2
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
         with:
           dependency-graph: generate-and-submit
       - name: Run Gradle tasks


### PR DESCRIPTION
Followup to the original pin PR. SHAs unchanged — only the trailing version comment is updated to the most-specific tag in the same semver-major family.

Why: `# v2` is meaningless to reviewers — they can't tell if it's v2.0.0 or v2.6.2. `# v2.6.2` is unambiguous.

gradle labels v1->v1.1.0 + v2->v2.12.0

Tracking: DEVPROD-1072